### PR TITLE
Set default ASSET_BUILD_URL

### DIFF
--- a/config/assets.php
+++ b/config/assets.php
@@ -26,5 +26,5 @@ return [
 	|
 	| This URL is used to properly generate the URL to built assets.
 	*/
-	'url'  => env( 'ASSET_BUILD_URL', null ),
+	'url'  => env( 'ASSET_BUILD_URL', \plugin_dir_url( __DIR__ ) ),
 ];


### PR DESCRIPTION
Without setting a default `ASSET_BUILD_URL` we have to manually add a `.env` field to make assets work correctly. However, by setting a default of `\plugin_dir_url( __DIR__ )` in the `assets.php` config, assets work out of the box, while still allowing the end user to customize the location.