### PR TITLE
Preparing for 1.0 release and PHPUnit 10

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - '*.x'
       - '*.*.x'
   pull_request:
   schedule:

--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - '*.x'
       - '*.*.x'
   pull_request:
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - '*.x'
       - '*.*.x'
   pull_request:
   schedule:
@@ -13,7 +14,7 @@ jobs:
   php-tests:
     strategy:
       matrix:
-        php: [8.0, 8.1, 8.2]
+        php: [8.1, 8.2]
         wordpress: ["latest"]
         multisite: [true, false]
     uses: alleyinteractive/.github/.github/workflows/php-tests.yml@main

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ vendor
 composer.lock
 bootstrap/cache
 .phpunit.result.cache
+.phpunit.cache/*
 .phpcs/*.json
 
 # Ignore temporary OS files

--- a/.phpunit.cache/test-results
+++ b/.phpunit.cache/test-results
@@ -1,1 +1,0 @@
-{"version":1,"defects":[],"times":{"App\\Tests\\Feature\\ExampleTest::test_example":0.001,"App\\Tests\\Feature\\ExampleTest::test_route":0.029}}

--- a/.phpunit.cache/test-results
+++ b/.phpunit.cache/test-results
@@ -1,0 +1,1 @@
+{"version":1,"defects":[],"times":{"App\\Tests\\Feature\\ExampleTest::test_example":0.001,"App\\Tests\\Feature\\ExampleTest::test_route":0.029}}

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
   "name": "alleyinteractive/mantle",
-  "type": "project",
   "description": "A site using the Mantle framework for WordPress",
   "license": "GPL-2.0-or-later",
+  "type": "project",
   "authors": [
     {
       "name": "Alley",
@@ -11,15 +11,22 @@
   ],
   "require": {
     "alleyinteractive/composer-wordpress-autoloader": "^1.0",
-    "alleyinteractive/mantle-framework": "^0.12",
+    "alleyinteractive/mantle-framework": "^1.0",
     "fakerphp/faker": "^1.23"
   },
   "require-dev": {
     "alleyinteractive/alley-coding-standards": "^2.0",
-    "nunomaduro/collision": "^6.4",
+    "nunomaduro/collision": "^7.0",
     "phpstan/phpstan": "1.10.15",
-    "phpunit/phpunit": "^9.6.10",
+    "phpunit/phpunit": "^9.3.3 || ^10.4.2",
     "szepeviktor/phpstan-wordpress": "^1.3"
+  },
+  "minimum-stability": "dev",
+  "prefer-stable": true,
+  "autoload-dev": {
+    "psr-4": {
+      "App\\Tests\\": "tests/"
+    }
   },
   "config": {
     "allow-plugins": {
@@ -41,8 +48,6 @@
       }
     }
   },
-  "minimum-stability": "dev",
-  "prefer-stable": true,
   "scripts": {
     "post-autoload-dump": [
       "bin/mantle package:discover",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,15 +1,15 @@
+<?xml version="1.0"?>
 <phpunit
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	bootstrap="tests/bootstrap.php"
 	backupGlobals="false"
 	colors="true"
-	convertErrorsToExceptions="true"
-	convertNoticesToExceptions="true"
-	convertWarningsToExceptions="true"
-	printerClass="NunoMaduro\Collision\Adapters\Phpunit\Printer"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.4/phpunit.xsd"
+	cacheDirectory=".phpunit.cache"
 >
-	<testsuites>
-		<testsuite name="general">
-			<directory prefix="test-" suffix=".php">tests</directory>
-		</testsuite>
-	</testsuites>
+  <testsuites>
+    <testsuite name="general">
+      <directory suffix="Test.php">tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/tests/CreateApplication.php
+++ b/tests/CreateApplication.php
@@ -13,7 +13,7 @@ use Mantle\Application\Application;
 /**
  * Concern for creating the application instance.
  */
-trait Create_Application {
+trait CreateApplication {
 	/**
 	 * Creates the application from the application instance.
 	 *

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,6 +10,6 @@ namespace App\Tests;
 /**
  * Base Test Case that each Test Case should extend.
  */
-abstract class Test_Case extends \Mantle\Testing\Test_Case {
-	use Create_Application;
+abstract class TestCase extends \Mantle\Testing\Test_Case {
+	use CreateApplication;
 }

--- a/tests/feature/ExampleTest.php
+++ b/tests/feature/ExampleTest.php
@@ -7,12 +7,12 @@
 
 namespace App\Tests\Feature;
 
-use App\Tests\Test_Case;
+use App\Tests\TestCase;
 
 /**
  * Base Test Case that each Test Case should extend.
  */
-class Test_Example extends Test_Case {
+class ExampleTest extends TestCase {
   public function test_example() {
     $this->assertTrue( true );
 	}


### PR DESCRIPTION
- Migrates tests to PSR-4.
- Upgrades `mantle-framework` to 1.0.
- Drops PHP 8.0 support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Renamed classes and traits for improved consistency and clarity in test files.

- **Tests**
  - Updated test execution times to be represented as a JSON object.
  - Renamed test classes for standardization.

- **Chores**
  - Enhanced GitHub workflow triggers to support version-like branch names (ending in `.x` and `*.*.x`).
  - Adjusted PHP versions in test workflows to include 8.1 and 8.2, removing version 8.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->